### PR TITLE
Create folder before downloading vector geojson data

### DIFF
--- a/opensearch-maps-server/Dockerfile
+++ b/opensearch-maps-server/Dockerfile
@@ -10,7 +10,8 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 
-RUN cd public/vectors/data && \
+RUN mkdir -p public/vectors/data  && \
+    cd public/vectors/data && \
     wget -O vectors.tar.gz https://maps.opensearch.org/offline/natural-earth-geo-json.tar.gz && \
     tar -xzf vectors.tar.gz --strip-components=1 && \
     rm vectors.tar.gz


### PR DESCRIPTION
### Description
By default, on Github it doesn’t keep empty folder, we want to have folder `public/vectors/data` to put vector geo json data which would be downloaded when build docker image. This pr helps to create a folder `public/vectors/data` during docker image build to avoid build error.

Tiles data folder will be created automatically by using docker volume operation `-v tiles-data:/usr/src/app/public/tiles/data/`.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).