### PR TITLE
Separate tiles bucket in gh actions and modify vector tiles path name

### DIFF
--- a/.github/workflows/planet-cdk-cd.yml
+++ b/.github/workflows/planet-cdk-cd.yml
@@ -39,7 +39,7 @@ jobs:
           PlanetVectorTileGeneration \
           EmailSNSPlanetRasterTileGeneration \
           SlackSNSPlanetRasterTileGeneration \
-          --context BUCKET=${{secrets.TILE_S3_BUCKET}} \
+          --context BUCKET=${{secrets.RASTER_TILES_BUCKET}} \
           --context EMAIL=${{secrets.EMAIL}} \
           --context SLACK=${{secrets.SLACK}} \
           --require-approval never
@@ -51,7 +51,7 @@ jobs:
           PlanetVectorTileGeneration \
           EmailSNSPlanetVectorTileGeneration \
           SlackSNSPlanetVectorTileGeneration \
-          --context BUCKET=${{secrets.TILE_S3_BUCKET}} \
+          --context BUCKET=${{secrets.VECTOR_TILES_BUKCET}} \
           --context EMAIL=${{secrets.EMAIL}} \
           --context SLACK=${{secrets.SLACK}} \
           --require-approval never

--- a/.github/workflows/test-cdk-cd.yml
+++ b/.github/workflows/test-cdk-cd.yml
@@ -80,6 +80,6 @@ jobs:
       - name: Run Test Vector Tiles ECS task
         run: |
           ClusterName=`jq -r '.TestVectorTileGeneration .ClusterName' tiles-generation/cdk/cdk-outputs-vector.json`
-          CapacityProviderName=`jq -r '.TestRasterTileGeneration .CapacityProviderName' tiles-generation/cdk/cdk-outputs-vector.json`
-          TaskDefinitionArn=`jq -r '.TestRasterTileGeneration .TaskDefinitionArn' tiles-generation/cdk/cdk-outputs-vector.json`
+          CapacityProviderName=`jq -r '.TestVectorTileGeneration .CapacityProviderName' tiles-generation/cdk/cdk-outputs-vector.json`
+          TaskDefinitionArn=`jq -r '.TestVectorTileGeneration .TaskDefinitionArn' tiles-generation/cdk/cdk-outputs-vector.json`
           aws ecs run-task --cluster $ClusterName --task-definition $TaskDefinitionArn --capacity-provider-strategy capacityProvider=$CapacityProviderName

--- a/tiles-generation/docker/vector-tile/entrypoint.sh
+++ b/tiles-generation/docker/vector-tile/entrypoint.sh
@@ -64,7 +64,7 @@ then
 
     # Upload to S3 Bucket
     currentTime=$(date "+%Y%m%d%H%M%S")
-    /s5cmd cp tiles/ s3://"${TILE_S3_BUCKET}"/"${AREA}"-VT-"${currentTime}"/vector/
+    /s5cmd cp tiles/ s3://"${TILE_S3_BUCKET}"/"${AREA}"-VT-"${currentTime}"/data/
     echo "tiles copy finished"
     exit 0
 fi


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
1. Separate raster and vector tiles bucket in prod Github actions
2. Modify vector tiles destination folder name so that the URL in CDN for vector tiles data would be https://tiles.maps.opensearch.org/data/0/0/0.pbf
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).