### PR TITLE
Use pull_request instead of pull_request_target in workflow for test-…

### DIFF
--- a/.github/workflows/test-cdk-cd.yml
+++ b/.github/workflows/test-cdk-cd.yml
@@ -1,7 +1,7 @@
 name: Test tiles generation CDK CD and ECS task run
 
 on: 
-  pull_request_target:
+  pull_request:
       branches:
         - main
       paths:


### PR DESCRIPTION
…cdk-cd.yml

### Description
RCE via vulnerable workflow in opensearch-project/maps repo.

Use pull_request instead of pull_request_target in workflow.
 
### Issues Resolved
RCE via vulnerable workflow in opensearch-project/maps repo
 