### PR TITLE
Update workflow to replace pull_request_target

### DIFF
--- a/.github/workflows/pr-approve-test.yml
+++ b/.github/workflows/pr-approve-test.yml
@@ -1,0 +1,29 @@
+name: Receive PR Test Approve
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'tiles-generation/**'
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        run: echo With security reasons, CDK test actions for tiles generation PR need to be approved before running.
+
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/test-cdk-cd.yml
+++ b/.github/workflows/test-cdk-cd.yml
@@ -1,24 +1,56 @@
-name: Test tiles generation CDK CD and ECS task run
+name: Test tiles generation CDK and ECS task run
 
-on: 
-  pull_request_target:
-      branches:
-        - main
-      paths:
-        - 'tiles-generation/**'
+on:
+  workflow_run:
+    workflows: ["Receive PR Test Approve"]
+    types:
+      - completed
 
 jobs:
-  approve:
+  comment:
     runs-on: ubuntu-latest
     steps:
-    - name: Approve
-      run: echo With security reasons, pull request need to be approved before running actions.
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            const matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            const download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip pr_number.zip
+      - name: 'Comment on PR'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const issue_number = Number(fs.readFileSync('./pr_number'));
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: 'Test tiles generation: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            });
   
   build:
     runs-on: ubuntu-latest
-    needs: [approve]
-    environment:
-        name: Pull Request
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Use `pull_request` and `workflow_run` to replace `pull_request_target` in workflow. the code in PR will be handled via the pull_request trigger with a manually approve so that it is isolated in an unprivileged environment. The following workflow then starts on `workflow_run` where it is granted access to repository secrets to execute cdk tasks.

Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Example for this change: https://github.com/junqiu-lei/maps/pull/14

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).