### PR TITLE
Fix: CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*   @heemin32 @navneet1v @VijayanB @jmazanec15 @vamshin @naveentatikonda @junqiu-lei @martin-gaievski
+# This should match the list in MAINTAINERS.md.
+*   @VijayanB @vamshin @junqiu-lei


### PR DESCRIPTION
### Description

Fixed CODEOWNERS to match list in MAINTAINERS.
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).