### PR TITLE
add support to import from local file

### DIFF
--- a/opensearch-maps-server/README.md
+++ b/opensearch-maps-server/README.md
@@ -41,10 +41,21 @@ Download the tiles set from the OpenSearch maps service. Two planet tiles sets a
 The planet tiles set for zoom level 10 (2 GB compressed/6.8 GB uncompressed) is approximately 10 times larger than the set for zoom level 8 (225 MB compressed/519 MB uncompressed).
 {: .note}
 
+Run the following command to download the tiles set and import it into the Docker volume:
 ```
 docker run \
     -e DOWNLOAD_TILES=https://maps.opensearch.org/offline/planet-osm-default-z0-z8.tar.gz \
     -v tiles-data:/usr/src/app/public/tiles/data/ \
+    opensearch/opensearch-maps-server \
+    import
+```
+
+Run the following command to import the tiles set from a local file:
+```
+docker run \
+    -e LOCAL_TILES=/tmp/planet-osm-default-z0-z8.tar.gz \
+    -v tiles-data:/usr/src/app/public/tiles/data/ \
+    -v ./planet-osm-default-z0-z8.tar.gz:/tmp/planet-osm-default-z0-z8.tar.gz \
     opensearch/opensearch-maps-server \
     import
 ```

--- a/opensearch-maps-server/entrypoint.sh
+++ b/opensearch-maps-server/entrypoint.sh
@@ -9,6 +9,7 @@ usage() {
     echo "    run: Serve tiles at /tile/data/{z}/{x}/{y}.png, manifest at /manifest.json"
     echo "environment variables:"
     echo "    DOWNLOAD_TILES: the url to download raster image tiles set from OpenSearch maps service"
+    echo "    LOCAL_TILES: the path to local raster image tiles set OpenSearch maps service"
     echo "    HOST_URL: the host machine ip address"
 }
 
@@ -24,6 +25,9 @@ if [ "${1}" = "import" ]; then
         curl -SL -o tiles.tar.gz "$DOWNLOAD_TILES"
         tar -xzf tiles.tar.gz --strip-components=1
         rm tiles.tar.gz
+    elif [ -n "${LOCAL_TILES:-}" ]; then
+        echo "INFO: Local Tiles images: $LOCAL_TILES"
+        tar -xzf $LOCAL_TILES --strip-components=1
     fi
     exit 0
 fi


### PR DESCRIPTION
### Description
For environments that are air-gapped it's not possible to access online resources.

With the addition of `LOCAL_TILES` environment variable, the import command can import a file mounted though a volume instead of running wget to download the resource from the internet.

### Issues Resolved
_n/a_

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).